### PR TITLE
Improve video editor configuration validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,13 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
-        
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>

--- a/src/main/java/com/example/authsystem/AuthSystemApplication.java
+++ b/src/main/java/com/example/authsystem/AuthSystemApplication.java
@@ -2,8 +2,10 @@ package com.example.authsystem;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class AuthSystemApplication {
     public static void main(String[] args) {
         SpringApplication.run(AuthSystemApplication.class, args);

--- a/src/main/java/com/example/authsystem/config/VideoEditorProperties.java
+++ b/src/main/java/com/example/authsystem/config/VideoEditorProperties.java
@@ -1,0 +1,64 @@
+package com.example.authsystem.config;
+
+import com.example.authsystem.dto.VideoQualityProfile;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Validated
+@ConfigurationProperties(prefix = "video-editor")
+public class VideoEditorProperties {
+
+    @NotBlank
+    private String ffmpegPath;
+
+    @NotBlank
+    private String workspacePath;
+
+    @NotBlank
+    private String outputPrefix;
+
+    @NotEmpty
+    private Map<String, @Valid VideoQualityProfile> qualityProfiles = new LinkedHashMap<>();
+
+    public String getFfmpegPath() {
+        return ffmpegPath;
+    }
+
+    public void setFfmpegPath(String ffmpegPath) {
+        this.ffmpegPath = ffmpegPath;
+    }
+
+    public String getWorkspacePath() {
+        return workspacePath;
+    }
+
+    public void setWorkspacePath(String workspacePath) {
+        this.workspacePath = workspacePath;
+    }
+
+    public String getOutputPrefix() {
+        return outputPrefix;
+    }
+
+    public void setOutputPrefix(String outputPrefix) {
+        this.outputPrefix = outputPrefix;
+    }
+
+    public Map<String, VideoQualityProfile> getQualityProfiles() {
+        return Map.copyOf(qualityProfiles);
+    }
+
+    public void setQualityProfiles(Map<String, VideoQualityProfile> qualityProfiles) {
+        if (qualityProfiles == null) {
+            this.qualityProfiles = new LinkedHashMap<>();
+        } else {
+            this.qualityProfiles = new LinkedHashMap<>(qualityProfiles);
+        }
+    }
+}

--- a/src/main/java/com/example/authsystem/controller/VideoEditorConfigController.java
+++ b/src/main/java/com/example/authsystem/controller/VideoEditorConfigController.java
@@ -1,0 +1,22 @@
+package com.example.authsystem.controller;
+
+import com.example.authsystem.config.VideoEditorProperties;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/video-editor")
+public class VideoEditorConfigController {
+
+    private final VideoEditorProperties properties;
+
+    public VideoEditorConfigController(VideoEditorProperties properties) {
+        this.properties = properties;
+    }
+
+    @GetMapping("/config")
+    public VideoEditorProperties getConfiguration() {
+        return properties;
+    }
+}

--- a/src/main/java/com/example/authsystem/dto/VideoQualityProfile.java
+++ b/src/main/java/com/example/authsystem/dto/VideoQualityProfile.java
@@ -1,0 +1,6 @@
+package com.example.authsystem.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record VideoQualityProfile(@NotBlank String resolution, @NotBlank String bitrate) {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,3 +45,19 @@ springdoc:
     path: /api-docs
   swagger-ui:
     path: /swagger-ui.html
+ 
+video-editor:
+  ffmpeg-path: /usr/bin/ffmpeg
+  workspace-path: /var/lib/auth-system/video-workspace
+  output-prefix: processed_
+  quality-profiles:
+    low:
+      resolution: 640x360
+      bitrate: 800k
+    medium:
+      resolution: 1280x720
+      bitrate: 2500k
+    high:
+      resolution: 1920x1080
+      bitrate: 5000k
+  # Values above provide sensible defaults and can be overridden via the admin UI or environment-specific configuration.


### PR DESCRIPTION
## Summary
- validate the video editor configuration properties with Jakarta validation annotations and expose them safely via an unmodifiable map
- ensure each quality profile entry also validates its resolution and bitrate fields
- keep the application configuration organized with an explicit separation between Swagger settings and the video editor defaults

## Testing
- `mvn test` *(fails: unable to download the Spring Boot parent POM from Maven Central due to HTTP 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f45f412c7c832a9b386248dc520700