### PR TITLE
Add video task domain, persistence, and REST management

### DIFF
--- a/src/main/java/com/example/authsystem/controller/VideoTaskController.java
+++ b/src/main/java/com/example/authsystem/controller/VideoTaskController.java
@@ -1,0 +1,198 @@
+package com.example.authsystem.controller;
+
+import com.example.authsystem.dto.VideoSegmentDTO;
+import com.example.authsystem.dto.VideoTaskLogRequest;
+import com.example.authsystem.dto.VideoTaskRequest;
+import com.example.authsystem.dto.VideoTaskResponse;
+import com.example.authsystem.dto.VideoTaskStatusUpdateRequest;
+import com.example.authsystem.entity.VideoSegment;
+import com.example.authsystem.entity.VideoTask;
+import com.example.authsystem.entity.VideoTaskStatus;
+import com.example.authsystem.service.VideoTaskService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/video-tasks")
+@Tag(name = "Video Task Management", description = "APIs for managing video processing tasks")
+public class VideoTaskController {
+
+    @Autowired
+    private VideoTaskService videoTaskService;
+
+    @PostMapping
+    @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
+    @Operation(summary = "Create video task", description = "Create a new video processing task and generate command preview")
+    public ResponseEntity<VideoTaskResponse> createTask(@Valid @RequestBody VideoTaskRequest request) {
+        VideoTask task = new VideoTask();
+        task.setSourceFileName(request.getSourceFileName());
+        task.setQualityProfile(request.getQualityProfile());
+        task.setSegments(mapSegments(request.getSegments()));
+        task.setCommandPreview(request.getCommandPreview());
+        VideoTask created = videoTaskService.createTask(task);
+        return ResponseEntity.ok(new VideoTaskResponse(created));
+    }
+
+    @GetMapping
+    @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
+    @Operation(summary = "List video tasks", description = "Query video tasks by status and creation date range")
+    public ResponseEntity<List<VideoTaskResponse>> listTasks(
+            @RequestParam(required = false) VideoTaskStatus status,
+            @RequestParam(required = false) List<VideoTaskStatus> statuses,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime to) {
+
+        List<VideoTask> tasks;
+        if (statuses != null && !statuses.isEmpty() && from != null && to != null) {
+            tasks = videoTaskService.findByStatusesAndCreatedRange(statuses, from, to);
+        } else if (status != null && from != null && to != null) {
+            tasks = videoTaskService.findByStatusesAndCreatedRange(List.of(status), from, to);
+        } else if (status != null) {
+            tasks = videoTaskService.findByStatus(status);
+        } else if (from != null && to != null) {
+            tasks = videoTaskService.findByCreatedRange(from, to);
+        } else {
+            tasks = videoTaskService.findAll();
+        }
+
+        List<VideoTaskResponse> responses = tasks.stream()
+                .map(VideoTaskResponse::new)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(responses);
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
+    @Operation(summary = "Get video task", description = "Retrieve a video task by id")
+    public ResponseEntity<VideoTaskResponse> getTask(@PathVariable Long id) {
+        return videoTaskService.findById(id)
+                .map(task -> ResponseEntity.ok(new VideoTaskResponse(task)))
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/{id}/command-preview")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
+    @Operation(summary = "Get command preview", description = "Retrieve generated command preview for a task")
+    public ResponseEntity<String> getCommandPreview(@PathVariable Long id) {
+        return videoTaskService.findById(id)
+                .map(task -> ResponseEntity.ok(task.getCommandPreview()))
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PatchMapping("/{id}/status")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
+    @Operation(summary = "Update status", description = "Update task status and append message")
+    public ResponseEntity<VideoTaskResponse> updateStatus(@PathVariable Long id,
+                                                         @Valid @RequestBody VideoTaskStatusUpdateRequest request) {
+        try {
+            VideoTask updated = videoTaskService.updateStatus(id, request.getStatus(), request.getMessage());
+            return ResponseEntity.ok(new VideoTaskResponse(updated));
+        } catch (IllegalArgumentException ex) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @PostMapping("/{id}/approve")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
+    @Operation(summary = "Approve task", description = "Approve pending video task")
+    public ResponseEntity<VideoTaskResponse> approveTask(@PathVariable Long id,
+                                                         @RequestBody(required = false) VideoTaskLogRequest request) {
+        try {
+            VideoTask updated = videoTaskService.approveTask(id, extractMessage(request));
+            return ResponseEntity.ok(new VideoTaskResponse(updated));
+        } catch (IllegalArgumentException ex) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @PostMapping("/{id}/reject")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
+    @Operation(summary = "Reject task", description = "Reject a video task during approval phase")
+    public ResponseEntity<VideoTaskResponse> rejectTask(@PathVariable Long id,
+                                                        @RequestBody(required = false) VideoTaskLogRequest request) {
+        try {
+            VideoTask updated = videoTaskService.rejectTask(id, extractMessage(request));
+            return ResponseEntity.ok(new VideoTaskResponse(updated));
+        } catch (IllegalArgumentException ex) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @PostMapping("/{id}/pause")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
+    @Operation(summary = "Pause task", description = "Pause an in-progress video task")
+    public ResponseEntity<VideoTaskResponse> pauseTask(@PathVariable Long id,
+                                                       @RequestBody(required = false) VideoTaskLogRequest request) {
+        try {
+            VideoTask updated = videoTaskService.pauseTask(id, extractMessage(request));
+            return ResponseEntity.ok(new VideoTaskResponse(updated));
+        } catch (IllegalArgumentException ex) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @PostMapping("/{id}/resume")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
+    @Operation(summary = "Resume task", description = "Resume a paused video task")
+    public ResponseEntity<VideoTaskResponse> resumeTask(@PathVariable Long id,
+                                                        @RequestBody(required = false) VideoTaskLogRequest request) {
+        try {
+            VideoTask updated = videoTaskService.resumeTask(id, extractMessage(request));
+            return ResponseEntity.ok(new VideoTaskResponse(updated));
+        } catch (IllegalArgumentException ex) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @PostMapping("/{id}/cancel")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
+    @Operation(summary = "Cancel task", description = "Cancel video task execution")
+    public ResponseEntity<VideoTaskResponse> cancelTask(@PathVariable Long id,
+                                                        @RequestBody(required = false) VideoTaskLogRequest request) {
+        try {
+            VideoTask updated = videoTaskService.cancelTask(id, extractMessage(request));
+            return ResponseEntity.ok(new VideoTaskResponse(updated));
+        } catch (IllegalArgumentException ex) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @PostMapping("/{id}/logs")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
+    @Operation(summary = "Record execution log", description = "Record execution message for a video task")
+    public ResponseEntity<VideoTaskResponse> logTaskProgress(@PathVariable Long id,
+                                                             @RequestBody(required = false) VideoTaskLogRequest request) {
+        try {
+            String message = extractMessage(request);
+            VideoTaskStatus status = request != null ? request.getStatus() : null;
+            VideoTask updated = videoTaskService.recordExecutionLog(id, message, status);
+            return ResponseEntity.ok(new VideoTaskResponse(updated));
+        } catch (IllegalArgumentException ex) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    private List<VideoSegment> mapSegments(List<VideoSegmentDTO> segmentDTOs) {
+        if (segmentDTOs == null) {
+            return new ArrayList<>();
+        }
+        return segmentDTOs.stream()
+                .map(dto -> new VideoSegment(dto.getStartSecond(), dto.getEndSecond(), dto.getSortOrder()))
+                .collect(Collectors.toList());
+    }
+
+    private String extractMessage(VideoTaskLogRequest request) {
+        return request != null ? request.getMessage() : null;
+    }
+}

--- a/src/main/java/com/example/authsystem/dto/VideoSegmentDTO.java
+++ b/src/main/java/com/example/authsystem/dto/VideoSegmentDTO.java
@@ -1,0 +1,43 @@
+package com.example.authsystem.dto;
+
+import com.example.authsystem.entity.VideoSegment;
+
+public class VideoSegmentDTO {
+
+    private Integer startSecond;
+    private Integer endSecond;
+    private Integer sortOrder;
+
+    public VideoSegmentDTO() {
+    }
+
+    public VideoSegmentDTO(VideoSegment segment) {
+        this.startSecond = segment.getStartSecond();
+        this.endSecond = segment.getEndSecond();
+        this.sortOrder = segment.getSortOrder();
+    }
+
+    public Integer getStartSecond() {
+        return startSecond;
+    }
+
+    public void setStartSecond(Integer startSecond) {
+        this.startSecond = startSecond;
+    }
+
+    public Integer getEndSecond() {
+        return endSecond;
+    }
+
+    public void setEndSecond(Integer endSecond) {
+        this.endSecond = endSecond;
+    }
+
+    public Integer getSortOrder() {
+        return sortOrder;
+    }
+
+    public void setSortOrder(Integer sortOrder) {
+        this.sortOrder = sortOrder;
+    }
+}

--- a/src/main/java/com/example/authsystem/dto/VideoTaskLogRequest.java
+++ b/src/main/java/com/example/authsystem/dto/VideoTaskLogRequest.java
@@ -1,0 +1,25 @@
+package com.example.authsystem.dto;
+
+import com.example.authsystem.entity.VideoTaskStatus;
+
+public class VideoTaskLogRequest {
+
+    private String message;
+    private VideoTaskStatus status;
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public VideoTaskStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(VideoTaskStatus status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/com/example/authsystem/dto/VideoTaskRequest.java
+++ b/src/main/java/com/example/authsystem/dto/VideoTaskRequest.java
@@ -1,0 +1,52 @@
+package com.example.authsystem.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class VideoTaskRequest {
+
+    @NotBlank
+    private String sourceFileName;
+
+    private String qualityProfile;
+
+    @Valid
+    private List<VideoSegmentDTO> segments = new ArrayList<>();
+
+    private String commandPreview;
+
+    public String getSourceFileName() {
+        return sourceFileName;
+    }
+
+    public void setSourceFileName(String sourceFileName) {
+        this.sourceFileName = sourceFileName;
+    }
+
+    public String getQualityProfile() {
+        return qualityProfile;
+    }
+
+    public void setQualityProfile(String qualityProfile) {
+        this.qualityProfile = qualityProfile;
+    }
+
+    public List<VideoSegmentDTO> getSegments() {
+        return segments;
+    }
+
+    public void setSegments(List<VideoSegmentDTO> segments) {
+        this.segments = segments != null ? segments : new ArrayList<>();
+    }
+
+    public String getCommandPreview() {
+        return commandPreview;
+    }
+
+    public void setCommandPreview(String commandPreview) {
+        this.commandPreview = commandPreview;
+    }
+}

--- a/src/main/java/com/example/authsystem/dto/VideoTaskResponse.java
+++ b/src/main/java/com/example/authsystem/dto/VideoTaskResponse.java
@@ -1,0 +1,71 @@
+package com.example.authsystem.dto;
+
+import com.example.authsystem.entity.VideoTask;
+import com.example.authsystem.entity.VideoTaskStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class VideoTaskResponse {
+
+    private Long id;
+    private String sourceFileName;
+    private String qualityProfile;
+    private VideoTaskStatus status;
+    private String commandPreview;
+    private String lastMessage;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private List<VideoSegmentDTO> segments;
+
+    public VideoTaskResponse(VideoTask task) {
+        this.id = task.getId();
+        this.sourceFileName = task.getSourceFileName();
+        this.qualityProfile = task.getQualityProfile();
+        this.status = task.getStatus();
+        this.commandPreview = task.getCommandPreview();
+        this.lastMessage = task.getLastMessage();
+        this.createdAt = task.getCreatedAt();
+        this.updatedAt = task.getUpdatedAt();
+        this.segments = task.getSegments().stream()
+                .map(VideoSegmentDTO::new)
+                .collect(Collectors.toList());
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getSourceFileName() {
+        return sourceFileName;
+    }
+
+    public String getQualityProfile() {
+        return qualityProfile;
+    }
+
+    public VideoTaskStatus getStatus() {
+        return status;
+    }
+
+    public String getCommandPreview() {
+        return commandPreview;
+    }
+
+    public String getLastMessage() {
+        return lastMessage;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public List<VideoSegmentDTO> getSegments() {
+        return segments;
+    }
+}

--- a/src/main/java/com/example/authsystem/dto/VideoTaskStatusUpdateRequest.java
+++ b/src/main/java/com/example/authsystem/dto/VideoTaskStatusUpdateRequest.java
@@ -1,0 +1,28 @@
+package com.example.authsystem.dto;
+
+import com.example.authsystem.entity.VideoTaskStatus;
+import jakarta.validation.constraints.NotNull;
+
+public class VideoTaskStatusUpdateRequest {
+
+    @NotNull
+    private VideoTaskStatus status;
+
+    private String message;
+
+    public VideoTaskStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(VideoTaskStatus status) {
+        this.status = status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/com/example/authsystem/entity/VideoSegment.java
+++ b/src/main/java/com/example/authsystem/entity/VideoSegment.java
@@ -1,0 +1,50 @@
+package com.example.authsystem.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class VideoSegment {
+
+    @Column(name = "start_second")
+    private Integer startSecond;
+
+    @Column(name = "end_second")
+    private Integer endSecond;
+
+    @Column(name = "sort_order")
+    private Integer sortOrder;
+
+    public VideoSegment() {
+    }
+
+    public VideoSegment(Integer startSecond, Integer endSecond, Integer sortOrder) {
+        this.startSecond = startSecond;
+        this.endSecond = endSecond;
+        this.sortOrder = sortOrder;
+    }
+
+    public Integer getStartSecond() {
+        return startSecond;
+    }
+
+    public void setStartSecond(Integer startSecond) {
+        this.startSecond = startSecond;
+    }
+
+    public Integer getEndSecond() {
+        return endSecond;
+    }
+
+    public void setEndSecond(Integer endSecond) {
+        this.endSecond = endSecond;
+    }
+
+    public Integer getSortOrder() {
+        return sortOrder;
+    }
+
+    public void setSortOrder(Integer sortOrder) {
+        this.sortOrder = sortOrder;
+    }
+}

--- a/src/main/java/com/example/authsystem/entity/VideoTask.java
+++ b/src/main/java/com/example/authsystem/entity/VideoTask.java
@@ -1,0 +1,129 @@
+package com.example.authsystem.entity;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "video_tasks")
+public class VideoTask {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "source_file_name", nullable = false)
+    private String sourceFileName;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "video_task_segments", joinColumns = @JoinColumn(name = "video_task_id"))
+    @OrderColumn(name = "segment_index")
+    private List<VideoSegment> segments = new ArrayList<>();
+
+    @Column(name = "quality_profile")
+    private String qualityProfile;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private VideoTaskStatus status = VideoTaskStatus.PENDING;
+
+    @Column(name = "command_preview", length = 1000)
+    private String commandPreview;
+
+    @Column(name = "last_message", length = 500)
+    private String lastMessage;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    public VideoTask() {
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getSourceFileName() {
+        return sourceFileName;
+    }
+
+    public void setSourceFileName(String sourceFileName) {
+        this.sourceFileName = sourceFileName;
+    }
+
+    public List<VideoSegment> getSegments() {
+        return segments;
+    }
+
+    public void setSegments(List<VideoSegment> segments) {
+        this.segments = segments != null ? new ArrayList<>(segments) : new ArrayList<>();
+    }
+
+    public String getQualityProfile() {
+        return qualityProfile;
+    }
+
+    public void setQualityProfile(String qualityProfile) {
+        this.qualityProfile = qualityProfile;
+    }
+
+    public VideoTaskStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(VideoTaskStatus status) {
+        this.status = status;
+    }
+
+    public String getCommandPreview() {
+        return commandPreview;
+    }
+
+    public void setCommandPreview(String commandPreview) {
+        this.commandPreview = commandPreview;
+    }
+
+    public String getLastMessage() {
+        return lastMessage;
+    }
+
+    public void setLastMessage(String lastMessage) {
+        this.lastMessage = lastMessage;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/com/example/authsystem/entity/VideoTaskStatus.java
+++ b/src/main/java/com/example/authsystem/entity/VideoTaskStatus.java
@@ -1,0 +1,11 @@
+package com.example.authsystem.entity;
+
+public enum VideoTaskStatus {
+    PENDING,
+    APPROVED,
+    RUNNING,
+    PAUSED,
+    CANCELLED,
+    COMPLETED,
+    FAILED
+}

--- a/src/main/java/com/example/authsystem/repository/VideoTaskRepository.java
+++ b/src/main/java/com/example/authsystem/repository/VideoTaskRepository.java
@@ -1,0 +1,18 @@
+package com.example.authsystem.repository;
+
+import com.example.authsystem.entity.VideoTask;
+import com.example.authsystem.entity.VideoTaskStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+
+public interface VideoTaskRepository extends JpaRepository<VideoTask, Long> {
+
+    List<VideoTask> findByStatus(VideoTaskStatus status);
+
+    List<VideoTask> findByStatusInAndCreatedAtBetween(Collection<VideoTaskStatus> statuses, LocalDateTime start, LocalDateTime end);
+
+    List<VideoTask> findByCreatedAtBetween(LocalDateTime start, LocalDateTime end);
+}

--- a/src/main/java/com/example/authsystem/service/VideoTaskService.java
+++ b/src/main/java/com/example/authsystem/service/VideoTaskService.java
@@ -1,0 +1,143 @@
+package com.example.authsystem.service;
+
+import com.example.authsystem.entity.VideoSegment;
+import com.example.authsystem.entity.VideoTask;
+import com.example.authsystem.entity.VideoTaskStatus;
+import com.example.authsystem.repository.VideoTaskRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+public class VideoTaskService {
+
+    @Autowired
+    private VideoTaskRepository videoTaskRepository;
+
+    public VideoTask createTask(VideoTask task) {
+        if (task.getStatus() == null) {
+            task.setStatus(VideoTaskStatus.PENDING);
+        }
+        if (task.getCommandPreview() == null || task.getCommandPreview().isBlank()) {
+            task.setCommandPreview(generateCommandPreview(task));
+        }
+        return videoTaskRepository.save(task);
+    }
+
+    public List<VideoTask> findAll() {
+        return videoTaskRepository.findAll();
+    }
+
+    public Optional<VideoTask> findById(Long id) {
+        return videoTaskRepository.findById(id);
+    }
+
+    public List<VideoTask> findByStatus(VideoTaskStatus status) {
+        return videoTaskRepository.findByStatus(status);
+    }
+
+    public List<VideoTask> findByStatusesAndCreatedRange(Collection<VideoTaskStatus> statuses, LocalDateTime start, LocalDateTime end) {
+        return videoTaskRepository.findByStatusInAndCreatedAtBetween(statuses, start, end);
+    }
+
+    public List<VideoTask> findByCreatedRange(LocalDateTime start, LocalDateTime end) {
+        return videoTaskRepository.findByCreatedAtBetween(start, end);
+    }
+
+    public VideoTask approveTask(Long id, String message) {
+        return updateStatus(getTaskOrThrow(id), VideoTaskStatus.APPROVED, message);
+    }
+
+    public VideoTask rejectTask(Long id, String message) {
+        return updateStatus(getTaskOrThrow(id), VideoTaskStatus.CANCELLED, message);
+    }
+
+    public VideoTask pauseTask(Long id, String message) {
+        return updateStatus(getTaskOrThrow(id), VideoTaskStatus.PAUSED, message);
+    }
+
+    public VideoTask resumeTask(Long id, String message) {
+        return updateStatus(getTaskOrThrow(id), VideoTaskStatus.RUNNING, message);
+    }
+
+    public VideoTask cancelTask(Long id, String message) {
+        return updateStatus(getTaskOrThrow(id), VideoTaskStatus.CANCELLED, message);
+    }
+
+    public VideoTask updateStatus(Long id, VideoTaskStatus status, String message) {
+        return updateStatus(getTaskOrThrow(id), status, message);
+    }
+
+    public VideoTask updateCommandPreview(Long id, String commandPreview) {
+        VideoTask task = getTaskOrThrow(id);
+        task.setCommandPreview(commandPreview);
+        return videoTaskRepository.save(task);
+    }
+
+    public VideoTask recordExecutionLog(Long id, String message, VideoTaskStatus status) {
+        VideoTask task = getTaskOrThrow(id);
+        if (status != null) {
+            task.setStatus(status);
+        }
+        if (message != null && !message.isBlank()) {
+            task.setLastMessage(message);
+        }
+        return videoTaskRepository.save(task);
+    }
+
+    public String generateCommandPreview(VideoTask task) {
+        StringBuilder builder = new StringBuilder("ffmpeg -i \"");
+        builder.append(task.getSourceFileName() != null ? task.getSourceFileName() : "input.mp4");
+        builder.append("\"");
+
+        List<VideoSegment> segments = task.getSegments();
+        if (segments != null && !segments.isEmpty()) {
+            String segmentPreview = segments.stream()
+                    .map(segment -> buildSegmentCommand(segment))
+                    .collect(Collectors.joining(" "));
+            if (!segmentPreview.isBlank()) {
+                builder.append(' ').append(segmentPreview);
+            }
+        }
+
+        if (task.getQualityProfile() != null && !task.getQualityProfile().isBlank()) {
+            builder.append(" -profile:v ").append(task.getQualityProfile());
+        }
+
+        builder.append(" \"output_");
+        builder.append(task.getQualityProfile() != null && !task.getQualityProfile().isBlank() ? task.getQualityProfile() : "processed");
+        builder.append(".mp4\"");
+
+        return builder.toString();
+    }
+
+    private String buildSegmentCommand(VideoSegment segment) {
+        StringBuilder builder = new StringBuilder();
+        if (segment.getStartSecond() != null) {
+            builder.append("-ss ").append(segment.getStartSecond()).append(' ');
+        }
+        if (segment.getEndSecond() != null) {
+            builder.append("-to ").append(segment.getEndSecond()).append(' ');
+        }
+        builder.append("-c copy");
+        return builder.toString().trim();
+    }
+
+    private VideoTask updateStatus(VideoTask task, VideoTaskStatus status, String message) {
+        task.setStatus(status);
+        if (message != null && !message.isBlank()) {
+            task.setLastMessage(message);
+        }
+        return videoTaskRepository.save(task);
+    }
+
+    private VideoTask getTaskOrThrow(Long id) {
+        return videoTaskRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Video task not found: " + id));
+    }
+}

--- a/src/main/resources/init-db.sql
+++ b/src/main/resources/init-db.sql
@@ -91,3 +91,33 @@ INSERT INTO role_menus (role_id, menu_id) VALUES
 INSERT INTO user_roles (user_id, role_id) VALUES
 (1, 1),  -- admin has ADMIN role
 (2, 2);  -- user1 has USER role
+
+-- Video tasks table
+CREATE TABLE IF NOT EXISTS video_tasks (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    source_file_name VARCHAR(255) NOT NULL,
+    quality_profile VARCHAR(100),
+    status VARCHAR(20) NOT NULL,
+    command_preview VARCHAR(1000),
+    last_message VARCHAR(500),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS video_task_segments (
+    video_task_id BIGINT NOT NULL,
+    segment_index INT NOT NULL,
+    start_second INT,
+    end_second INT,
+    sort_order INT,
+    PRIMARY KEY (video_task_id, segment_index),
+    FOREIGN KEY (video_task_id) REFERENCES video_tasks(id) ON DELETE CASCADE
+);
+
+-- Sample video task data
+INSERT INTO video_tasks (source_file_name, quality_profile, status, command_preview, last_message)
+VALUES ('sample-source.mp4', 'HD', 'PENDING', 'ffmpeg -i "sample-source.mp4" -profile:v HD "output_HD.mp4"', 'Awaiting approval');
+
+INSERT INTO video_task_segments (video_task_id, segment_index, start_second, end_second, sort_order)
+VALUES (1, 0, 0, 60, 1),
+       (1, 1, 120, 180, 2);


### PR DESCRIPTION
## Summary
- add the VideoTask aggregate with persisted segments, status tracking, and timestamps
- expose lifecycle management through a dedicated service, repository, DTOs, and secured REST controller
- seed the database script with video task tables and sample data for H2/MySQL setups

## Testing
- `mvn -q -DskipTests compile` *(fails: unable to download Spring Boot parent due to 403 from Maven Central in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f45f4275c0832abf9cc3ee1b957e02