### PR TITLE
Add FFmpeg command execution workflow for video tasks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,11 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/example/authsystem/config/VideoEditorProperties.java
+++ b/src/main/java/com/example/authsystem/config/VideoEditorProperties.java
@@ -1,0 +1,39 @@
+package com.example.authsystem.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "video.editor")
+public class VideoEditorProperties {
+
+    private String ffmpegPath = "ffmpeg";
+
+    private String workspacePath = ".";
+
+    private String outputPrefix = "output";
+
+    public String getFfmpegPath() {
+        return ffmpegPath;
+    }
+
+    public void setFfmpegPath(String ffmpegPath) {
+        this.ffmpegPath = ffmpegPath;
+    }
+
+    public String getWorkspacePath() {
+        return workspacePath;
+    }
+
+    public void setWorkspacePath(String workspacePath) {
+        this.workspacePath = workspacePath;
+    }
+
+    public String getOutputPrefix() {
+        return outputPrefix;
+    }
+
+    public void setOutputPrefix(String outputPrefix) {
+        this.outputPrefix = outputPrefix;
+    }
+}

--- a/src/main/java/com/example/authsystem/config/VideoTaskExecutorConfig.java
+++ b/src/main/java/com/example/authsystem/config/VideoTaskExecutorConfig.java
@@ -1,0 +1,21 @@
+package com.example.authsystem.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+public class VideoTaskExecutorConfig {
+
+    @Bean(name = "videoTaskExecutor")
+    public TaskExecutor videoTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(1);
+        executor.setQueueCapacity(10);
+        executor.setThreadNamePrefix("video-task-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/example/authsystem/controller/VideoTaskController.java
+++ b/src/main/java/com/example/authsystem/controller/VideoTaskController.java
@@ -1,0 +1,41 @@
+package com.example.authsystem.controller;
+
+import com.example.authsystem.dto.CommandPreviewResponse;
+import com.example.authsystem.service.VideoTaskService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/video-tasks")
+@Tag(name = "Video Task", description = "Video editing task APIs")
+public class VideoTaskController {
+
+    private final VideoTaskService videoTaskService;
+
+    public VideoTaskController(VideoTaskService videoTaskService) {
+        this.videoTaskService = videoTaskService;
+    }
+
+    @GetMapping("/{id}/command-preview")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Get FFmpeg command preview", description = "Preview the FFmpeg command for an approved task")
+    public ResponseEntity<CommandPreviewResponse> getCommandPreview(@PathVariable("id") Long id) {
+        String command = videoTaskService.getCommandPreview(id);
+        return ResponseEntity.ok(new CommandPreviewResponse(command));
+    }
+
+    @PostMapping("/{id}/execute")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Confirm execution", description = "Trigger FFmpeg execution for an approved task")
+    public ResponseEntity<Void> confirmExecution(@PathVariable("id") Long id) {
+        videoTaskService.confirmExecution(id);
+        return ResponseEntity.accepted().build();
+    }
+}

--- a/src/main/java/com/example/authsystem/dto/CommandPreviewResponse.java
+++ b/src/main/java/com/example/authsystem/dto/CommandPreviewResponse.java
@@ -1,0 +1,21 @@
+package com.example.authsystem.dto;
+
+public class CommandPreviewResponse {
+
+    private String command;
+
+    public CommandPreviewResponse() {
+    }
+
+    public CommandPreviewResponse(String command) {
+        this.command = command;
+    }
+
+    public String getCommand() {
+        return command;
+    }
+
+    public void setCommand(String command) {
+        this.command = command;
+    }
+}

--- a/src/main/java/com/example/authsystem/entity/VideoSegment.java
+++ b/src/main/java/com/example/authsystem/entity/VideoSegment.java
@@ -1,0 +1,38 @@
+package com.example.authsystem.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class VideoSegment {
+
+    @Column(name = "start_time")
+    private String startTime;
+
+    @Column(name = "end_time")
+    private String endTime;
+
+    public VideoSegment() {
+    }
+
+    public VideoSegment(String startTime, String endTime) {
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
+    public String getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(String startTime) {
+        this.startTime = startTime;
+    }
+
+    public String getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(String endTime) {
+        this.endTime = endTime;
+    }
+}

--- a/src/main/java/com/example/authsystem/entity/VideoTask.java
+++ b/src/main/java/com/example/authsystem/entity/VideoTask.java
@@ -1,0 +1,158 @@
+package com.example.authsystem.entity;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "video_tasks")
+public class VideoTask {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "input_file", nullable = false)
+    private String inputFile;
+
+    @Column(name = "output_file", nullable = false)
+    private String outputFile;
+
+    @Column(name = "video_bitrate")
+    private String videoBitrate;
+
+    @Column(name = "scale_width")
+    private Integer scaleWidth;
+
+    @Column(name = "scale_height")
+    private Integer scaleHeight;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private VideoTaskStatus status = VideoTaskStatus.PENDING_APPROVAL;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "video_task_segments", joinColumns = @JoinColumn(name = "task_id"))
+    private List<VideoSegment> segments = new ArrayList<>();
+
+    @Column(name = "execution_log", length = 4000)
+    private String executionLog;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getInputFile() {
+        return inputFile;
+    }
+
+    public void setInputFile(String inputFile) {
+        this.inputFile = inputFile;
+    }
+
+    public String getOutputFile() {
+        return outputFile;
+    }
+
+    public void setOutputFile(String outputFile) {
+        this.outputFile = outputFile;
+    }
+
+    public String getVideoBitrate() {
+        return videoBitrate;
+    }
+
+    public void setVideoBitrate(String videoBitrate) {
+        this.videoBitrate = videoBitrate;
+    }
+
+    public Integer getScaleWidth() {
+        return scaleWidth;
+    }
+
+    public void setScaleWidth(Integer scaleWidth) {
+        this.scaleWidth = scaleWidth;
+    }
+
+    public Integer getScaleHeight() {
+        return scaleHeight;
+    }
+
+    public void setScaleHeight(Integer scaleHeight) {
+        this.scaleHeight = scaleHeight;
+    }
+
+    public VideoTaskStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(VideoTaskStatus status) {
+        this.status = status;
+    }
+
+    public List<VideoSegment> getSegments() {
+        return segments;
+    }
+
+    public void setSegments(List<VideoSegment> segments) {
+        this.segments = segments;
+    }
+
+    public String getExecutionLog() {
+        return executionLog;
+    }
+
+    public void setExecutionLog(String executionLog) {
+        this.executionLog = executionLog;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public void appendLog(String message) {
+        if (message == null || message.isBlank()) {
+            return;
+        }
+        if (executionLog == null || executionLog.isBlank()) {
+            executionLog = message;
+        } else {
+            executionLog = executionLog + System.lineSeparator() + message;
+        }
+    }
+}

--- a/src/main/java/com/example/authsystem/entity/VideoTaskStatus.java
+++ b/src/main/java/com/example/authsystem/entity/VideoTaskStatus.java
@@ -1,0 +1,10 @@
+package com.example.authsystem.entity;
+
+public enum VideoTaskStatus {
+    PENDING_APPROVAL,
+    APPROVED,
+    RUNNING,
+    COMPLETED,
+    FAILED,
+    REJECTED
+}

--- a/src/main/java/com/example/authsystem/repository/VideoTaskRepository.java
+++ b/src/main/java/com/example/authsystem/repository/VideoTaskRepository.java
@@ -1,0 +1,9 @@
+package com.example.authsystem.repository;
+
+import com.example.authsystem.entity.VideoTask;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface VideoTaskRepository extends JpaRepository<VideoTask, Long> {
+}

--- a/src/main/java/com/example/authsystem/service/FfmpegCommandBuilder.java
+++ b/src/main/java/com/example/authsystem/service/FfmpegCommandBuilder.java
@@ -1,0 +1,98 @@
+package com.example.authsystem.service;
+
+import com.example.authsystem.config.VideoEditorProperties;
+import com.example.authsystem.entity.VideoSegment;
+import com.example.authsystem.entity.VideoTask;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class FfmpegCommandBuilder {
+
+    private final VideoEditorProperties properties;
+
+    public FfmpegCommandBuilder(VideoEditorProperties properties) {
+        this.properties = properties;
+    }
+
+    public FfmpegCommand build(VideoTask task) {
+        List<String> arguments = new ArrayList<>();
+        arguments.add(properties.getFfmpegPath());
+        addSegmentArguments(task, arguments);
+        addVideoFilters(task, arguments);
+        arguments.add(task.getOutputFile());
+        return new FfmpegCommand(arguments);
+    }
+
+    private void addSegmentArguments(VideoTask task, List<String> arguments) {
+        List<VideoSegment> segments = task.getSegments();
+        if (segments == null || segments.isEmpty()) {
+            arguments.add("-i");
+            arguments.add(task.getInputFile());
+            return;
+        }
+
+        for (VideoSegment segment : segments) {
+            if (StringUtils.hasText(segment.getStartTime())) {
+                arguments.add("-ss");
+                arguments.add(segment.getStartTime());
+            }
+            if (StringUtils.hasText(segment.getEndTime())) {
+                arguments.add("-to");
+                arguments.add(segment.getEndTime());
+            }
+            arguments.add("-i");
+            arguments.add(task.getInputFile());
+        }
+    }
+
+    private void addVideoFilters(VideoTask task, List<String> arguments) {
+        if (StringUtils.hasText(task.getVideoBitrate())) {
+            arguments.add("-b:v");
+            arguments.add(task.getVideoBitrate());
+        }
+
+        Integer width = task.getScaleWidth();
+        Integer height = task.getScaleHeight();
+        if (width != null || height != null) {
+            int w = width != null ? width : -1;
+            int h = height != null ? height : -1;
+            arguments.add("-vf");
+            arguments.add("scale=" + w + ":" + h);
+        }
+    }
+
+    public static class FfmpegCommand {
+        private final List<String> arguments;
+        private final String preview;
+
+        private FfmpegCommand(List<String> arguments) {
+            this.arguments = arguments;
+            this.preview = arguments.stream()
+                    .map(FfmpegCommandBuilder::quoteIfNeeded)
+                    .collect(Collectors.joining(" "));
+        }
+
+        public List<String> getArguments() {
+            return arguments;
+        }
+
+        public String getPreview() {
+            return preview;
+        }
+    }
+
+    private static String quoteIfNeeded(String value) {
+        if (!StringUtils.hasText(value)) {
+            return "";
+        }
+        if (value.contains(" ") || value.contains("\t")) {
+            return '"' + value + '"';
+        }
+        return value;
+    }
+}

--- a/src/main/java/com/example/authsystem/service/FfmpegExecutionService.java
+++ b/src/main/java/com/example/authsystem/service/FfmpegExecutionService.java
@@ -1,0 +1,72 @@
+package com.example.authsystem.service;
+
+import com.example.authsystem.config.VideoEditorProperties;
+import com.example.authsystem.entity.VideoTask;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+@Service
+public class FfmpegExecutionService {
+
+    private final VideoEditorProperties properties;
+    private final ProcessBuilderFactory processBuilderFactory;
+
+    public FfmpegExecutionService(VideoEditorProperties properties, ProcessBuilderFactory processBuilderFactory) {
+        this.properties = properties;
+        this.processBuilderFactory = processBuilderFactory;
+    }
+
+    public boolean execute(VideoTask task, List<String> command) {
+        validateOutputFile(task.getOutputFile());
+        ProcessBuilder processBuilder = processBuilderFactory.create(command);
+        processBuilder.directory(new File(properties.getWorkspacePath()));
+
+        try {
+            Process process = processBuilder.start();
+            int exitCode = process.waitFor();
+            String stdout;
+            try (InputStream inputStream = process.getInputStream()) {
+                stdout = readStream(inputStream);
+            }
+            String stderr;
+            try (InputStream errorStream = process.getErrorStream()) {
+                stderr = readStream(errorStream);
+            }
+            StringBuilder logBuilder = new StringBuilder();
+            logBuilder.append("Command: ").append(String.join(" ", command)).append(System.lineSeparator());
+            if (StringUtils.hasText(stdout)) {
+                logBuilder.append("[STDOUT]").append(System.lineSeparator()).append(stdout.trim()).append(System.lineSeparator());
+            }
+            if (StringUtils.hasText(stderr)) {
+                logBuilder.append("[STDERR]").append(System.lineSeparator()).append(stderr.trim()).append(System.lineSeparator());
+            }
+            logBuilder.append("Exit code: ").append(exitCode);
+            task.appendLog(logBuilder.toString());
+            return exitCode == 0;
+        } catch (IOException e) {
+            task.appendLog("Execution failed: " + e.getMessage());
+            return false;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            task.appendLog("Execution interrupted: " + e.getMessage());
+            return false;
+        }
+    }
+
+    private void validateOutputFile(String outputFile) {
+        String prefix = properties.getOutputPrefix();
+        if (StringUtils.hasText(prefix) && (outputFile == null || !outputFile.startsWith(prefix))) {
+            throw new IllegalArgumentException("Output file must start with configured prefix: " + prefix);
+        }
+    }
+
+    private String readStream(InputStream inputStream) throws IOException {
+        return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+    }
+}

--- a/src/main/java/com/example/authsystem/service/ProcessBuilderFactory.java
+++ b/src/main/java/com/example/authsystem/service/ProcessBuilderFactory.java
@@ -1,0 +1,13 @@
+package com.example.authsystem.service;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class ProcessBuilderFactory {
+
+    public ProcessBuilder create(List<String> command) {
+        return new ProcessBuilder(command);
+    }
+}

--- a/src/main/java/com/example/authsystem/service/VideoTaskService.java
+++ b/src/main/java/com/example/authsystem/service/VideoTaskService.java
@@ -1,0 +1,80 @@
+package com.example.authsystem.service;
+
+import com.example.authsystem.entity.VideoTask;
+import com.example.authsystem.entity.VideoTaskStatus;
+import com.example.authsystem.repository.VideoTaskRepository;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+
+@Service
+public class VideoTaskService {
+
+    private final VideoTaskRepository videoTaskRepository;
+    private final FfmpegCommandBuilder commandBuilder;
+    private final FfmpegExecutionService executionService;
+    private final TaskExecutor taskExecutor;
+
+    public VideoTaskService(VideoTaskRepository videoTaskRepository,
+                            FfmpegCommandBuilder commandBuilder,
+                            FfmpegExecutionService executionService,
+                            @Qualifier("videoTaskExecutor") TaskExecutor taskExecutor) {
+        this.videoTaskRepository = videoTaskRepository;
+        this.commandBuilder = commandBuilder;
+        this.executionService = executionService;
+        this.taskExecutor = taskExecutor != null ? taskExecutor : Runnable::run;
+    }
+
+    public String getCommandPreview(Long taskId) {
+        VideoTask task = loadTask(taskId);
+        ensureApproved(task);
+        return commandBuilder.build(task).getPreview();
+    }
+
+    public void confirmExecution(Long taskId) {
+        VideoTask task = loadTask(taskId);
+        ensureApproved(task);
+        taskExecutor.execute(() -> runTask(taskId));
+    }
+
+    public VideoTask approveTask(Long taskId) {
+        VideoTask task = loadTask(taskId);
+        task.setStatus(VideoTaskStatus.APPROVED);
+        return videoTaskRepository.save(task);
+    }
+
+    private void runTask(Long taskId) {
+        VideoTask task = loadTask(taskId);
+        task.setStatus(VideoTaskStatus.RUNNING);
+        videoTaskRepository.save(task);
+
+        FfmpegCommandBuilder.FfmpegCommand command = commandBuilder.build(task);
+        boolean success;
+        try {
+            success = executionService.execute(task, command.getArguments());
+        } catch (RuntimeException ex) {
+            task.appendLog("Execution raised exception: " + ex.getMessage());
+            success = false;
+        }
+
+        task.setStatus(success ? VideoTaskStatus.COMPLETED : VideoTaskStatus.FAILED);
+        videoTaskRepository.save(task);
+    }
+
+    private VideoTask loadTask(Long taskId) {
+        Assert.notNull(taskId, "Task id must not be null");
+        Optional<VideoTask> optionalTask = videoTaskRepository.findById(taskId);
+        return optionalTask.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Video task not found"));
+    }
+
+    private void ensureApproved(VideoTask task) {
+        if (task.getStatus() != VideoTaskStatus.APPROVED) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Video task must be approved before execution");
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,3 +45,10 @@ springdoc:
     path: /api-docs
   swagger-ui:
     path: /swagger-ui.html
+
+video:
+  editor:
+    ffmpeg-path: ffmpeg
+    workspace-path: ./workspace
+    output-prefix: output/
+

--- a/src/test/java/com/example/authsystem/service/FfmpegExecutionServiceTest.java
+++ b/src/test/java/com/example/authsystem/service/FfmpegExecutionServiceTest.java
@@ -1,0 +1,102 @@
+package com.example.authsystem.service;
+
+import com.example.authsystem.config.VideoEditorProperties;
+import com.example.authsystem.entity.VideoTask;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FfmpegExecutionServiceTest {
+
+    private VideoEditorProperties properties;
+
+    @Mock
+    private ProcessBuilderFactory processBuilderFactory;
+
+    @Mock
+    private ProcessBuilder processBuilder;
+
+    @Mock
+    private Process process;
+
+    private FfmpegExecutionService executionService;
+
+    @BeforeEach
+    void setUp() {
+        properties = new VideoEditorProperties();
+        properties.setFfmpegPath("ffmpeg");
+        properties.setWorkspacePath("/tmp");
+        properties.setOutputPrefix("output/");
+        executionService = new FfmpegExecutionService(properties, processBuilderFactory);
+    }
+
+    @Test
+    void executeShouldCaptureOutputAndReturnSuccess() throws Exception {
+        List<String> command = List.of("ffmpeg", "-i", "input.mp4", "output/result.mp4");
+        VideoTask task = new VideoTask();
+        task.setOutputFile("output/result.mp4");
+
+        when(processBuilderFactory.create(command)).thenReturn(processBuilder);
+        when(processBuilder.directory(any(File.class))).thenReturn(processBuilder);
+        when(processBuilder.start()).thenReturn(process);
+        when(process.waitFor()).thenReturn(0);
+        when(process.getInputStream()).thenReturn(stream("success"));
+        when(process.getErrorStream()).thenReturn(stream(""));
+
+        boolean success = executionService.execute(task, command);
+
+        assertTrue(success);
+        assertNotNull(task.getExecutionLog());
+        assertTrue(task.getExecutionLog().contains("success"));
+        ArgumentCaptor<File> directoryCaptor = ArgumentCaptor.forClass(File.class);
+        verify(processBuilder).directory(directoryCaptor.capture());
+        assertEquals(new File("/tmp"), directoryCaptor.getValue());
+    }
+
+    @Test
+    void executeShouldReturnFalseOnFailure() throws Exception {
+        List<String> command = List.of("ffmpeg", "-i", "input.mp4", "output/result.mp4");
+        VideoTask task = new VideoTask();
+        task.setOutputFile("output/result.mp4");
+
+        when(processBuilderFactory.create(command)).thenReturn(processBuilder);
+        when(processBuilder.directory(any(File.class))).thenReturn(processBuilder);
+        when(processBuilder.start()).thenReturn(process);
+        when(process.waitFor()).thenReturn(1);
+        when(process.getInputStream()).thenReturn(stream(""));
+        when(process.getErrorStream()).thenReturn(stream("error"));
+
+        boolean success = executionService.execute(task, command);
+
+        assertFalse(success);
+        assertNotNull(task.getExecutionLog());
+        assertTrue(task.getExecutionLog().contains("error"));
+    }
+
+    @Test
+    void executeShouldValidateOutputPrefix() {
+        List<String> command = List.of("ffmpeg", "-i", "input.mp4", "invalid/result.mp4");
+        VideoTask task = new VideoTask();
+        task.setOutputFile("invalid/result.mp4");
+
+        assertThrows(IllegalArgumentException.class, () -> executionService.execute(task, command));
+        verifyNoInteractions(processBuilderFactory);
+    }
+
+    private InputStream stream(String value) {
+        return new ByteArrayInputStream(value.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/test/java/com/example/authsystem/service/VideoTaskServiceTest.java
+++ b/src/test/java/com/example/authsystem/service/VideoTaskServiceTest.java
@@ -1,0 +1,98 @@
+package com.example.authsystem.service;
+
+import com.example.authsystem.entity.VideoTask;
+import com.example.authsystem.entity.VideoTaskStatus;
+import com.example.authsystem.repository.VideoTaskRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class VideoTaskServiceTest {
+
+    @Mock
+    private VideoTaskRepository videoTaskRepository;
+
+    @Mock
+    private FfmpegCommandBuilder commandBuilder;
+
+    @Mock
+    private FfmpegExecutionService executionService;
+
+    private TaskExecutor taskExecutor;
+
+    private VideoTaskService videoTaskService;
+
+    private VideoTask task;
+
+    @BeforeEach
+    void setUp() {
+        taskExecutor = Runnable::run;
+        MockitoAnnotations.openMocks(this);
+        videoTaskService = new VideoTaskService(videoTaskRepository, commandBuilder, executionService, taskExecutor);
+        task = new VideoTask();
+        task.setId(1L);
+        task.setStatus(VideoTaskStatus.APPROVED);
+        task.setInputFile("input.mp4");
+        task.setOutputFile("output/result.mp4");
+    }
+
+    @Test
+    void confirmExecutionShouldUpdateStatuses() {
+        when(videoTaskRepository.findById(1L)).thenReturn(Optional.of(task), Optional.of(task));
+        FfmpegCommandBuilder.FfmpegCommand command = mock(FfmpegCommandBuilder.FfmpegCommand.class);
+        when(command.getArguments()).thenReturn(List.of("ffmpeg", "-i", "input.mp4", "output/result.mp4"));
+        when(commandBuilder.build(any(VideoTask.class))).thenReturn(command);
+        when(executionService.execute(any(VideoTask.class), eq(command.getArguments()))).thenReturn(true);
+
+        videoTaskService.confirmExecution(1L);
+
+        ArgumentCaptor<VideoTask> captor = ArgumentCaptor.forClass(VideoTask.class);
+        verify(videoTaskRepository, times(2)).save(captor.capture());
+        List<VideoTask> savedTasks = captor.getAllValues();
+        assertEquals(VideoTaskStatus.RUNNING, savedTasks.get(0).getStatus());
+        assertEquals(VideoTaskStatus.COMPLETED, savedTasks.get(1).getStatus());
+    }
+
+    @Test
+    void confirmExecutionShouldMarkFailedWhenExecutionFails() {
+        when(videoTaskRepository.findById(1L)).thenReturn(Optional.of(task), Optional.of(task));
+        FfmpegCommandBuilder.FfmpegCommand command = mock(FfmpegCommandBuilder.FfmpegCommand.class);
+        when(command.getArguments()).thenReturn(List.of("ffmpeg", "-i", "input.mp4", "output/result.mp4"));
+        when(commandBuilder.build(any(VideoTask.class))).thenReturn(command);
+        when(executionService.execute(any(VideoTask.class), eq(command.getArguments()))).thenReturn(false);
+
+        videoTaskService.confirmExecution(1L);
+
+        ArgumentCaptor<VideoTask> captor = ArgumentCaptor.forClass(VideoTask.class);
+        verify(videoTaskRepository, times(2)).save(captor.capture());
+        List<VideoTask> savedTasks = captor.getAllValues();
+        assertEquals(VideoTaskStatus.RUNNING, savedTasks.get(0).getStatus());
+        assertEquals(VideoTaskStatus.FAILED, savedTasks.get(1).getStatus());
+    }
+
+    @Test
+    void getCommandPreviewShouldThrowWhenNotApproved() {
+        task.setStatus(VideoTaskStatus.PENDING_APPROVAL);
+        when(videoTaskRepository.findById(1L)).thenReturn(Optional.of(task));
+
+        assertThrows(ResponseStatusException.class, () -> videoTaskService.getCommandPreview(1L));
+    }
+
+    @Test
+    void confirmExecutionShouldThrowWhenNotApproved() {
+        task.setStatus(VideoTaskStatus.PENDING_APPROVAL);
+        when(videoTaskRepository.findById(1L)).thenReturn(Optional.of(task));
+
+        assertThrows(ResponseStatusException.class, () -> videoTaskService.confirmExecution(1L));
+    }
+}


### PR DESCRIPTION
## Summary
- add video task entity, repository, and configuration properties to describe FFmpeg execution context
- implement command builder and execution services with logging, workspace enforcement, and process handling
- expose command preview and execution endpoints plus single-thread executor wiring and unit tests for execution and task services

## Testing
- `mvn -q test` *(fails: cannot download Spring Boot parent POM in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f45f43dfc8832abb87fe21409b97cd