### PR TITLE
feat: add AI-assisted video task drafting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
         
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -86,6 +91,12 @@
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.2.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-openai-spring-boot-starter</artifactId>
+            <version>0.8.1</version>
         </dependency>
 
         <!-- Test -->

--- a/src/main/java/com/example/authsystem/AuthSystemApplication.java
+++ b/src/main/java/com/example/authsystem/AuthSystemApplication.java
@@ -1,9 +1,12 @@
 package com.example.authsystem;
 
+import com.example.authsystem.config.AiProviderProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
+@EnableConfigurationProperties(AiProviderProperties.class)
 public class AuthSystemApplication {
     public static void main(String[] args) {
         SpringApplication.run(AuthSystemApplication.class, args);

--- a/src/main/java/com/example/authsystem/config/AiClientManager.java
+++ b/src/main/java/com/example/authsystem/config/AiClientManager.java
@@ -1,0 +1,77 @@
+package com.example.authsystem.config;
+
+import com.example.authsystem.entity.AiApiCredential;
+import com.example.authsystem.repository.AiApiCredentialRepository;
+import jakarta.annotation.PostConstruct;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+public class AiClientManager {
+
+    private static final Logger log = LoggerFactory.getLogger(AiClientManager.class);
+
+    private final AiProviderProperties properties;
+
+    private final AiApiCredentialRepository credentialRepository;
+
+    private final AtomicReference<ChatClient> chatClientRef = new AtomicReference<>();
+
+    public AiClientManager(AiProviderProperties properties,
+            AiApiCredentialRepository credentialRepository) {
+        this.properties = properties;
+        this.credentialRepository = credentialRepository;
+    }
+
+    @PostConstruct
+    public void initialize() {
+        refresh();
+    }
+
+    public ChatClient currentClient() {
+        ChatClient client = chatClientRef.get();
+        if (client == null) {
+            refresh();
+            client = chatClientRef.get();
+        }
+        return client;
+    }
+
+    public synchronized void refresh() {
+        String apiKey = resolveApiKey();
+        if (!StringUtils.hasText(apiKey)) {
+            chatClientRef.set(null);
+            log.warn("AI API key is not configured; ChatClient is disabled until a key is provided.");
+            return;
+        }
+        try {
+            OpenAiApi api = new OpenAiApi(apiKey);
+            OpenAiChatOptions options = OpenAiChatOptions.builder()
+                    .withModel(properties.getModel())
+                    .build();
+            OpenAiChatModel model = new OpenAiChatModel(api, options);
+            chatClientRef.set(ChatClient.create(model));
+            log.info("ChatClient refreshed for provider {} using model {}", properties.getProvider(), properties.getModel());
+        } catch (Exception ex) {
+            chatClientRef.set(null);
+            log.error("Failed to initialize ChatClient: {}", ex.getMessage(), ex);
+        }
+    }
+
+    private String resolveApiKey() {
+        String provider = StringUtils.hasText(properties.getProvider()) ? properties.getProvider() : "openai";
+        Optional<AiApiCredential> credential = credentialRepository.findByProvider(provider);
+        if (credential.isPresent()) {
+            return credential.get().decodedKey();
+        }
+        return properties.getApiKey();
+    }
+}

--- a/src/main/java/com/example/authsystem/config/AiProviderProperties.java
+++ b/src/main/java/com/example/authsystem/config/AiProviderProperties.java
@@ -1,0 +1,52 @@
+package com.example.authsystem.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
+
+@ConfigurationProperties(prefix = "ai")
+public class AiProviderProperties {
+
+    private String provider = "openai";
+
+    private String apiKey;
+
+    private String model = "gpt-3.5-turbo";
+
+    private String baseUrl;
+
+    public String getProvider() {
+        return provider;
+    }
+
+    public void setProvider(String provider) {
+        if (StringUtils.hasText(provider)) {
+            this.provider = provider;
+        }
+    }
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public void setApiKey(String apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public void setModel(String model) {
+        if (StringUtils.hasText(model)) {
+            this.model = model;
+        }
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+}

--- a/src/main/java/com/example/authsystem/controller/AiProviderController.java
+++ b/src/main/java/com/example/authsystem/controller/AiProviderController.java
@@ -1,0 +1,43 @@
+package com.example.authsystem.controller;
+
+import com.example.authsystem.dto.AiApiKeyRequest;
+import com.example.authsystem.dto.AiApiKeyValidationRequest;
+import com.example.authsystem.dto.ApiKeyValidationResponse;
+import com.example.authsystem.service.AiApiKeyService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/ai")
+@Tag(name = "AI Provider", description = "AI provider configuration APIs")
+public class AiProviderController {
+
+    private final AiApiKeyService aiApiKeyService;
+
+    public AiProviderController(AiApiKeyService aiApiKeyService) {
+        this.aiApiKeyService = aiApiKeyService;
+    }
+
+    @PostMapping("/api-key")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Update AI API key", description = "Persist a new API key for the configured AI provider and refresh the runtime client.")
+    public ResponseEntity<Void> updateApiKey(@Valid @RequestBody AiApiKeyRequest request) {
+        aiApiKeyService.updateApiKey(request);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/api-key/validate")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Validate AI API key", description = "Check whether the provided API key matches the currently stored secret.")
+    public ResponseEntity<ApiKeyValidationResponse> validateApiKey(@Valid @RequestBody AiApiKeyValidationRequest request) {
+        boolean valid = aiApiKeyService.validate(request);
+        return ResponseEntity.ok(new ApiKeyValidationResponse(valid));
+    }
+}

--- a/src/main/java/com/example/authsystem/controller/VideoTaskController.java
+++ b/src/main/java/com/example/authsystem/controller/VideoTaskController.java
@@ -1,0 +1,41 @@
+package com.example.authsystem.controller;
+
+import com.example.authsystem.dto.VideoInstructionRequest;
+import com.example.authsystem.dto.VideoTaskResponse;
+import com.example.authsystem.dto.video.VideoTaskDraft;
+import com.example.authsystem.entity.VideoTask;
+import com.example.authsystem.service.VideoInstructionParser;
+import com.example.authsystem.service.VideoTaskService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/video-tasks")
+@Tag(name = "Video Tasks", description = "Video task drafting and workflow APIs")
+public class VideoTaskController {
+
+    private final VideoInstructionParser videoInstructionParser;
+    private final VideoTaskService videoTaskService;
+
+    public VideoTaskController(VideoInstructionParser videoInstructionParser, VideoTaskService videoTaskService) {
+        this.videoInstructionParser = videoInstructionParser;
+        this.videoTaskService = videoTaskService;
+    }
+
+    @PostMapping("/from-instruction")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "Create a draft video task", description = "Convert free text instructions into a structured video editing task and store it for approval.")
+    public ResponseEntity<VideoTaskResponse> createTaskFromInstruction(@Valid @RequestBody VideoInstructionRequest request) {
+        VideoTaskDraft draft = videoInstructionParser.parse(request.getInstruction());
+        VideoTask task = videoTaskService.createPendingTask(request.getInstruction(), draft);
+        VideoTaskResponse response = videoTaskService.toResponse(task);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/example/authsystem/dto/AiApiKeyRequest.java
+++ b/src/main/java/com/example/authsystem/dto/AiApiKeyRequest.java
@@ -1,0 +1,27 @@
+package com.example.authsystem.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class AiApiKeyRequest {
+
+    private String provider;
+
+    @NotBlank(message = "API key must not be empty")
+    private String apiKey;
+
+    public String getProvider() {
+        return provider;
+    }
+
+    public void setProvider(String provider) {
+        this.provider = provider;
+    }
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public void setApiKey(String apiKey) {
+        this.apiKey = apiKey;
+    }
+}

--- a/src/main/java/com/example/authsystem/dto/AiApiKeyValidationRequest.java
+++ b/src/main/java/com/example/authsystem/dto/AiApiKeyValidationRequest.java
@@ -1,0 +1,27 @@
+package com.example.authsystem.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class AiApiKeyValidationRequest {
+
+    private String provider;
+
+    @NotBlank(message = "API key must not be empty")
+    private String apiKey;
+
+    public String getProvider() {
+        return provider;
+    }
+
+    public void setProvider(String provider) {
+        this.provider = provider;
+    }
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public void setApiKey(String apiKey) {
+        this.apiKey = apiKey;
+    }
+}

--- a/src/main/java/com/example/authsystem/dto/ApiKeyValidationResponse.java
+++ b/src/main/java/com/example/authsystem/dto/ApiKeyValidationResponse.java
@@ -1,0 +1,18 @@
+package com.example.authsystem.dto;
+
+public class ApiKeyValidationResponse {
+
+    private boolean valid;
+
+    public ApiKeyValidationResponse(boolean valid) {
+        this.valid = valid;
+    }
+
+    public boolean isValid() {
+        return valid;
+    }
+
+    public void setValid(boolean valid) {
+        this.valid = valid;
+    }
+}

--- a/src/main/java/com/example/authsystem/dto/VideoInstructionRequest.java
+++ b/src/main/java/com/example/authsystem/dto/VideoInstructionRequest.java
@@ -1,0 +1,17 @@
+package com.example.authsystem.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class VideoInstructionRequest {
+
+    @NotBlank(message = "Instruction text must not be empty")
+    private String instruction;
+
+    public String getInstruction() {
+        return instruction;
+    }
+
+    public void setInstruction(String instruction) {
+        this.instruction = instruction;
+    }
+}

--- a/src/main/java/com/example/authsystem/dto/VideoTaskResponse.java
+++ b/src/main/java/com/example/authsystem/dto/VideoTaskResponse.java
@@ -1,0 +1,81 @@
+package com.example.authsystem.dto;
+
+import com.example.authsystem.dto.video.VideoSegmentDraft;
+import com.example.authsystem.video.VideoQualityTier;
+import com.example.authsystem.video.VideoTaskStatus;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+public class VideoTaskResponse {
+
+    private Long id;
+
+    private String fileName;
+
+    private VideoQualityTier qualityTier;
+
+    private VideoTaskStatus status;
+
+    private List<VideoSegmentDraft> segments = new ArrayList<>();
+
+    private String originalInstruction;
+
+    private LocalDateTime createdAt;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public VideoQualityTier getQualityTier() {
+        return qualityTier;
+    }
+
+    public void setQualityTier(VideoQualityTier qualityTier) {
+        this.qualityTier = qualityTier;
+    }
+
+    public VideoTaskStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(VideoTaskStatus status) {
+        this.status = status;
+    }
+
+    public List<VideoSegmentDraft> getSegments() {
+        return segments;
+    }
+
+    public void setSegments(List<VideoSegmentDraft> segments) {
+        this.segments = segments;
+    }
+
+    public String getOriginalInstruction() {
+        return originalInstruction;
+    }
+
+    public void setOriginalInstruction(String originalInstruction) {
+        this.originalInstruction = originalInstruction;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/example/authsystem/dto/video/VideoSegmentDraft.java
+++ b/src/main/java/com/example/authsystem/dto/video/VideoSegmentDraft.java
@@ -1,0 +1,47 @@
+package com.example.authsystem.dto.video;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class VideoSegmentDraft {
+
+    private String title;
+
+    private String description;
+
+    private String startTimecode;
+
+    private String endTimecode;
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getStartTimecode() {
+        return startTimecode;
+    }
+
+    public void setStartTimecode(String startTimecode) {
+        this.startTimecode = startTimecode;
+    }
+
+    public String getEndTimecode() {
+        return endTimecode;
+    }
+
+    public void setEndTimecode(String endTimecode) {
+        this.endTimecode = endTimecode;
+    }
+}

--- a/src/main/java/com/example/authsystem/dto/video/VideoTaskDraft.java
+++ b/src/main/java/com/example/authsystem/dto/video/VideoTaskDraft.java
@@ -1,0 +1,39 @@
+package com.example.authsystem.dto.video;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.ArrayList;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class VideoTaskDraft {
+
+    private String fileName;
+
+    private String qualityTier;
+
+    private List<VideoSegmentDraft> segments = new ArrayList<>();
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public String getQualityTier() {
+        return qualityTier;
+    }
+
+    public void setQualityTier(String qualityTier) {
+        this.qualityTier = qualityTier;
+    }
+
+    public List<VideoSegmentDraft> getSegments() {
+        return segments;
+    }
+
+    public void setSegments(List<VideoSegmentDraft> segments) {
+        this.segments = segments;
+    }
+}

--- a/src/main/java/com/example/authsystem/entity/AiApiCredential.java
+++ b/src/main/java/com/example/authsystem/entity/AiApiCredential.java
@@ -1,0 +1,97 @@
+package com.example.authsystem.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.Base64;
+
+@Entity
+@Table(name = "ai_api_credentials")
+public class AiApiCredential {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String provider;
+
+    @Column(name = "encoded_key", nullable = false, length = 2048)
+    private String encodedKey;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public AiApiCredential() {
+    }
+
+    public AiApiCredential(String provider, String encodedKey) {
+        this.provider = provider;
+        this.encodedKey = encodedKey;
+    }
+
+    @PrePersist
+    public void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    public void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getProvider() {
+        return provider;
+    }
+
+    public void setProvider(String provider) {
+        this.provider = provider;
+    }
+
+    public String getEncodedKey() {
+        return encodedKey;
+    }
+
+    public void setEncodedKey(String encodedKey) {
+        this.encodedKey = encodedKey;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public String decodedKey() {
+        if (encodedKey == null) {
+            return null;
+        }
+        byte[] bytes = Base64.getDecoder().decode(encodedKey);
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+
+    public static String encode(String apiKey) {
+        if (apiKey == null) {
+            return null;
+        }
+        return Base64.getEncoder().encodeToString(apiKey.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/main/java/com/example/authsystem/entity/VideoTask.java
+++ b/src/main/java/com/example/authsystem/entity/VideoTask.java
@@ -1,0 +1,125 @@
+package com.example.authsystem.entity;
+
+import com.example.authsystem.video.VideoQualityTier;
+import com.example.authsystem.video.VideoTaskStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "video_tasks")
+public class VideoTask {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Lob
+    @Column(name = "original_instruction", nullable = false)
+    private String originalInstruction;
+
+    @Column(name = "file_name", nullable = false)
+    private String fileName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "quality_tier", nullable = false)
+    private VideoQualityTier qualityTier;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private VideoTaskStatus status = VideoTaskStatus.PENDING_APPROVAL;
+
+    @Lob
+    @Column(name = "segments_json", nullable = false)
+    private String segmentsJson;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public VideoTask() {
+    }
+
+    public VideoTask(String originalInstruction, String fileName, VideoQualityTier qualityTier, String segmentsJson) {
+        this.originalInstruction = originalInstruction;
+        this.fileName = fileName;
+        this.qualityTier = qualityTier;
+        this.segmentsJson = segmentsJson;
+        this.status = VideoTaskStatus.PENDING_APPROVAL;
+    }
+
+    @PrePersist
+    public void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    public void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getOriginalInstruction() {
+        return originalInstruction;
+    }
+
+    public void setOriginalInstruction(String originalInstruction) {
+        this.originalInstruction = originalInstruction;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public VideoQualityTier getQualityTier() {
+        return qualityTier;
+    }
+
+    public void setQualityTier(VideoQualityTier qualityTier) {
+        this.qualityTier = qualityTier;
+    }
+
+    public VideoTaskStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(VideoTaskStatus status) {
+        this.status = status;
+    }
+
+    public String getSegmentsJson() {
+        return segmentsJson;
+    }
+
+    public void setSegmentsJson(String segmentsJson) {
+        this.segmentsJson = segmentsJson;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/src/main/java/com/example/authsystem/repository/AiApiCredentialRepository.java
+++ b/src/main/java/com/example/authsystem/repository/AiApiCredentialRepository.java
@@ -1,0 +1,10 @@
+package com.example.authsystem.repository;
+
+import com.example.authsystem.entity.AiApiCredential;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AiApiCredentialRepository extends JpaRepository<AiApiCredential, Long> {
+
+    Optional<AiApiCredential> findByProvider(String provider);
+}

--- a/src/main/java/com/example/authsystem/repository/VideoTaskRepository.java
+++ b/src/main/java/com/example/authsystem/repository/VideoTaskRepository.java
@@ -1,0 +1,7 @@
+package com.example.authsystem.repository;
+
+import com.example.authsystem.entity.VideoTask;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VideoTaskRepository extends JpaRepository<VideoTask, Long> {
+}

--- a/src/main/java/com/example/authsystem/service/AiApiKeyService.java
+++ b/src/main/java/com/example/authsystem/service/AiApiKeyService.java
@@ -1,0 +1,64 @@
+package com.example.authsystem.service;
+
+import com.example.authsystem.config.AiClientManager;
+import com.example.authsystem.config.AiProviderProperties;
+import com.example.authsystem.dto.AiApiKeyRequest;
+import com.example.authsystem.dto.AiApiKeyValidationRequest;
+import com.example.authsystem.entity.AiApiCredential;
+import com.example.authsystem.repository.AiApiCredentialRepository;
+import jakarta.transaction.Transactional;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+public class AiApiKeyService {
+
+    private final AiApiCredentialRepository credentialRepository;
+    private final AiProviderProperties properties;
+    private final AiClientManager aiClientManager;
+
+    public AiApiKeyService(AiApiCredentialRepository credentialRepository,
+            AiProviderProperties properties,
+            AiClientManager aiClientManager) {
+        this.credentialRepository = credentialRepository;
+        this.properties = properties;
+        this.aiClientManager = aiClientManager;
+    }
+
+    public Optional<String> currentApiKey() {
+        String provider = defaultProvider();
+        return credentialRepository.findByProvider(provider)
+                .map(AiApiCredential::decodedKey)
+                .filter(StringUtils::hasText)
+                .or(() -> Optional.ofNullable(properties.getApiKey()).filter(StringUtils::hasText));
+    }
+
+    @Transactional
+    public void updateApiKey(AiApiKeyRequest request) {
+        String provider = resolveProvider(request.getProvider());
+        String encoded = AiApiCredential.encode(request.getApiKey());
+        AiApiCredential credential = credentialRepository.findByProvider(provider)
+                .orElse(new AiApiCredential(provider, encoded));
+        credential.setEncodedKey(encoded);
+        credentialRepository.save(credential);
+        properties.setApiKey(request.getApiKey());
+        aiClientManager.refresh();
+    }
+
+    public boolean validate(AiApiKeyValidationRequest request) {
+        String provider = resolveProvider(request.getProvider());
+        return credentialRepository.findByProvider(provider)
+                .map(AiApiCredential::decodedKey)
+                .map(stored -> stored.equals(request.getApiKey()))
+                .orElseGet(() -> request.getApiKey().equals(properties.getApiKey()));
+    }
+
+    private String resolveProvider(String provider) {
+        return StringUtils.hasText(provider) ? provider : defaultProvider();
+    }
+
+    private String defaultProvider() {
+        return StringUtils.hasText(properties.getProvider()) ? properties.getProvider() : "openai";
+    }
+}

--- a/src/main/java/com/example/authsystem/service/VideoInstructionParser.java
+++ b/src/main/java/com/example/authsystem/service/VideoInstructionParser.java
@@ -1,0 +1,105 @@
+package com.example.authsystem.service;
+
+import com.example.authsystem.config.AiClientManager;
+import com.example.authsystem.dto.video.VideoSegmentDraft;
+import com.example.authsystem.dto.video.VideoTaskDraft;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+public class VideoInstructionParser {
+
+    private static final Logger log = LoggerFactory.getLogger(VideoInstructionParser.class);
+
+    private static final DateTimeFormatter FILE_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    private final AiClientManager aiClientManager;
+    private final ObjectMapper objectMapper;
+
+    public VideoInstructionParser(AiClientManager aiClientManager, ObjectMapper objectMapper) {
+        this.aiClientManager = aiClientManager;
+        this.objectMapper = objectMapper;
+    }
+
+    public VideoTaskDraft parse(String instructionText) {
+        if (!StringUtils.hasText(instructionText)) {
+            throw new IllegalArgumentException("Instruction text must not be empty");
+        }
+        ChatClient client = aiClientManager.currentClient();
+        if (client == null) {
+            log.warn("ChatClient is not available, falling back to rule-based parsing");
+            return fallbackDraft(instructionText);
+        }
+
+        String systemPrompt = "You are an expert video post-production assistant. "
+                + "Read the user's instructions and respond with JSON that matches the schema: {\n"
+                + "  \"fileName\": string,\n"
+                + "  \"qualityTier\": one of [LOW, MEDIUM, HIGH, ULTRA],\n"
+                + "  \"segments\": [\n"
+                + "    {\"title\": string, \"description\": string, \"startTimecode\": string, \"endTimecode\": string}\n"
+                + "  ]\n"
+                + "}. Do not include markdown. Use \"MEDIUM\" when unsure about quality.";
+
+        try {
+            String response = client.prompt()
+                    .system(systemPrompt)
+                    .user(instructionText)
+                    .call()
+                    .content();
+            if (!StringUtils.hasText(response)) {
+                log.warn("Empty response returned from ChatClient, using fallback parser");
+                return fallbackDraft(instructionText);
+            }
+            VideoTaskDraft draft = objectMapper.readValue(response, VideoTaskDraft.class);
+            ensureDraftDefaults(draft, instructionText);
+            return draft;
+        } catch (Exception ex) {
+            log.warn("Failed to parse instruction using AI model, using fallback parser", ex);
+            return fallbackDraft(instructionText);
+        }
+    }
+
+    private void ensureDraftDefaults(VideoTaskDraft draft, String instructionText) {
+        if (!StringUtils.hasText(draft.getFileName())) {
+            draft.setFileName(generateFileName());
+        }
+        if (draft.getSegments() == null || draft.getSegments().isEmpty()) {
+            draft.setSegments(defaultSegments(instructionText));
+        }
+        if (!StringUtils.hasText(draft.getQualityTier())) {
+            draft.setQualityTier("MEDIUM");
+        }
+    }
+
+    private VideoTaskDraft fallbackDraft(String instructionText) {
+        VideoTaskDraft draft = new VideoTaskDraft();
+        draft.setFileName(generateFileName());
+        draft.setQualityTier("MEDIUM");
+        draft.setSegments(defaultSegments(instructionText));
+        return draft;
+    }
+
+    private List<VideoSegmentDraft> defaultSegments(String instructionText) {
+        List<VideoSegmentDraft> segments = new ArrayList<>();
+        VideoSegmentDraft segment = new VideoSegmentDraft();
+        segment.setTitle("Initial Cut");
+        segment.setDescription(instructionText);
+        segment.setStartTimecode("00:00:00:00");
+        segment.setEndTimecode("00:01:00:00");
+        segments.add(segment);
+        return segments;
+    }
+
+    private String generateFileName() {
+        return "video-" + FILE_DATE_FORMAT.format(LocalDate.now()) + "-" + UUID.randomUUID().toString().substring(0, 8) + ".mp4";
+    }
+}

--- a/src/main/java/com/example/authsystem/service/VideoTaskService.java
+++ b/src/main/java/com/example/authsystem/service/VideoTaskService.java
@@ -1,0 +1,72 @@
+package com.example.authsystem.service;
+
+import com.example.authsystem.dto.VideoTaskResponse;
+import com.example.authsystem.dto.video.VideoSegmentDraft;
+import com.example.authsystem.dto.video.VideoTaskDraft;
+import com.example.authsystem.entity.VideoTask;
+import com.example.authsystem.repository.VideoTaskRepository;
+import com.example.authsystem.video.VideoQualityTier;
+import com.example.authsystem.video.VideoTaskStatus;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collections;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+public class VideoTaskService {
+
+    private static final Logger log = LoggerFactory.getLogger(VideoTaskService.class);
+
+    private static final TypeReference<List<VideoSegmentDraft>> SEGMENT_TYPE = new TypeReference<>() {
+    };
+
+    private final VideoTaskRepository videoTaskRepository;
+    private final ObjectMapper objectMapper;
+
+    public VideoTaskService(VideoTaskRepository videoTaskRepository, ObjectMapper objectMapper) {
+        this.videoTaskRepository = videoTaskRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    public VideoTask createPendingTask(String instruction, VideoTaskDraft draft) {
+        VideoQualityTier tier = VideoQualityTier.fromValue(draft.getQualityTier());
+        String segmentsJson = serializeSegments(draft.getSegments());
+        VideoTask task = new VideoTask(instruction, draft.getFileName(), tier, segmentsJson);
+        task.setStatus(VideoTaskStatus.PENDING_APPROVAL);
+        return videoTaskRepository.save(task);
+    }
+
+    public VideoTaskResponse toResponse(VideoTask task) {
+        VideoTaskResponse response = new VideoTaskResponse();
+        response.setId(task.getId());
+        response.setFileName(task.getFileName());
+        response.setQualityTier(task.getQualityTier());
+        response.setStatus(task.getStatus());
+        response.setOriginalInstruction(task.getOriginalInstruction());
+        response.setCreatedAt(task.getCreatedAt());
+        response.setSegments(deserializeSegments(task.getSegmentsJson()));
+        return response;
+    }
+
+    private String serializeSegments(List<VideoSegmentDraft> segments) {
+        try {
+            return objectMapper.writeValueAsString(segments);
+        } catch (JsonProcessingException e) {
+            log.warn("Failed to serialize video segments, storing empty list", e);
+            return "[]";
+        }
+    }
+
+    private List<VideoSegmentDraft> deserializeSegments(String json) {
+        try {
+            return objectMapper.readValue(json, SEGMENT_TYPE);
+        } catch (Exception e) {
+            log.warn("Failed to deserialize video segments", e);
+            return Collections.emptyList();
+        }
+    }
+}

--- a/src/main/java/com/example/authsystem/video/VideoQualityTier.java
+++ b/src/main/java/com/example/authsystem/video/VideoQualityTier.java
@@ -1,0 +1,24 @@
+package com.example.authsystem.video;
+
+import java.util.Locale;
+import org.springframework.util.StringUtils;
+
+public enum VideoQualityTier {
+    LOW,
+    MEDIUM,
+    HIGH,
+    ULTRA;
+
+    public static VideoQualityTier fromValue(String value) {
+        if (!StringUtils.hasText(value)) {
+            return MEDIUM;
+        }
+        String normalized = value.trim().toUpperCase(Locale.ROOT).replace('-', '_').replace(' ', '_');
+        for (VideoQualityTier tier : values()) {
+            if (tier.name().equals(normalized)) {
+                return tier;
+            }
+        }
+        return MEDIUM;
+    }
+}

--- a/src/main/java/com/example/authsystem/video/VideoTaskStatus.java
+++ b/src/main/java/com/example/authsystem/video/VideoTaskStatus.java
@@ -1,0 +1,7 @@
+package com.example.authsystem.video;
+
+public enum VideoTaskStatus {
+    PENDING_APPROVAL,
+    APPROVED,
+    REJECTED
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,3 +45,9 @@ springdoc:
     path: /api-docs
   swagger-ui:
     path: /swagger-ui.html
+
+ai:
+  provider: ${AI_PROVIDER:openai}
+  api-key: ${AI_API_KEY:demo-api-key}
+  model: ${AI_MODEL:gpt-3.5-turbo}
+  base-url: ${AI_BASE_URL:}


### PR DESCRIPTION
## Summary
- add Spring AI OpenAI starter and supporting application properties for provider, key, and model selection
- introduce AI client management, instruction parsing services, and persistence for drafted video tasks
- expose secured endpoints for drafting tasks from free text and updating or validating AI API keys

## Testing
- `mvn -q -DskipTests package` *(fails: Maven Central responded with HTTP 403 when resolving the Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68f45f44f510832abef7b3c7cd48538f