### PR TITLE
Add workspace validation and video task management

### DIFF
--- a/src/main/java/com/example/authsystem/AuthSystemApplication.java
+++ b/src/main/java/com/example/authsystem/AuthSystemApplication.java
@@ -1,9 +1,12 @@
 package com.example.authsystem;
 
+import com.example.authsystem.config.VideoEditorProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
+@EnableConfigurationProperties(VideoEditorProperties.class)
 public class AuthSystemApplication {
     public static void main(String[] args) {
         SpringApplication.run(AuthSystemApplication.class, args);

--- a/src/main/java/com/example/authsystem/config/VideoEditorProperties.java
+++ b/src/main/java/com/example/authsystem/config/VideoEditorProperties.java
@@ -1,0 +1,49 @@
+package com.example.authsystem.config;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+@Validated
+@ConfigurationProperties(prefix = "video-editor")
+public class VideoEditorProperties {
+
+    @NotNull
+    private Path workspacePath;
+
+    @NotEmpty
+    private List<String> allowedExtensions = new ArrayList<>();
+
+    @NotBlank
+    private String outputPrefix;
+
+    public Path getWorkspacePath() {
+        return workspacePath;
+    }
+
+    public void setWorkspacePath(Path workspacePath) {
+        this.workspacePath = workspacePath;
+    }
+
+    public List<String> getAllowedExtensions() {
+        return allowedExtensions;
+    }
+
+    public void setAllowedExtensions(List<String> allowedExtensions) {
+        this.allowedExtensions = allowedExtensions;
+    }
+
+    public String getOutputPrefix() {
+        return outputPrefix;
+    }
+
+    public void setOutputPrefix(String outputPrefix) {
+        this.outputPrefix = outputPrefix;
+    }
+}

--- a/src/main/java/com/example/authsystem/controller/VideoTaskController.java
+++ b/src/main/java/com/example/authsystem/controller/VideoTaskController.java
@@ -1,0 +1,63 @@
+package com.example.authsystem.controller;
+
+import com.example.authsystem.dto.VideoTaskRequest;
+import com.example.authsystem.service.VideoTaskService;
+import com.example.authsystem.service.WorkspaceService;
+import com.example.authsystem.video.VideoTask;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@RestController
+@RequestMapping("/api/video")
+public class VideoTaskController {
+
+    private final VideoTaskService videoTaskService;
+    private final WorkspaceService workspaceService;
+
+    public VideoTaskController(VideoTaskService videoTaskService, WorkspaceService workspaceService) {
+        this.videoTaskService = videoTaskService;
+        this.workspaceService = workspaceService;
+    }
+
+    @PostMapping("/tasks")
+    public ResponseEntity<VideoTask> createTask(@Valid @RequestBody VideoTaskRequest request) {
+        VideoTask task = videoTaskService.createTask(request.getFilename());
+        return ResponseEntity.ok(task);
+    }
+
+    @PostMapping("/tasks/{taskId}/execute")
+    public ResponseEntity<VideoTask> executeTask(@PathVariable long taskId) {
+        try {
+            VideoTask task = videoTaskService.executeTask(taskId);
+            return ResponseEntity.ok(task);
+        } catch (NoSuchElementException ex) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @GetMapping("/tasks")
+    public List<VideoTask> listTasks() {
+        return videoTaskService.getAllTasks();
+    }
+
+    @GetMapping("/tasks/{taskId}")
+    public ResponseEntity<VideoTask> getTask(@PathVariable long taskId) {
+        return videoTaskService.getTask(taskId)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/workspace")
+    public List<String> browseWorkspace() {
+        return workspaceService.listWorkspaceContents();
+    }
+}

--- a/src/main/java/com/example/authsystem/dto/VideoTaskRequest.java
+++ b/src/main/java/com/example/authsystem/dto/VideoTaskRequest.java
@@ -1,0 +1,17 @@
+package com.example.authsystem.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class VideoTaskRequest {
+
+    @NotBlank
+    private String filename;
+
+    public String getFilename() {
+        return filename;
+    }
+
+    public void setFilename(String filename) {
+        this.filename = filename;
+    }
+}

--- a/src/main/java/com/example/authsystem/service/VideoTaskService.java
+++ b/src/main/java/com/example/authsystem/service/VideoTaskService.java
@@ -1,0 +1,89 @@
+package com.example.authsystem.service;
+
+import com.example.authsystem.video.VideoTask;
+import com.example.authsystem.video.VideoTaskStatus;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Comparator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Service
+public class VideoTaskService {
+
+    private final WorkspaceService workspaceService;
+    private final AtomicLong idGenerator = new AtomicLong();
+    private final ConcurrentMap<Long, VideoTask> tasks = new ConcurrentHashMap<>();
+
+    public VideoTaskService(WorkspaceService workspaceService) {
+        this.workspaceService = workspaceService;
+    }
+
+    public VideoTask createTask(String userProvidedFile) {
+        long id = idGenerator.incrementAndGet();
+        VideoTask task = new VideoTask(id, userProvidedFile);
+        try {
+            Path inputPath = workspaceService.resolveInputFile(userProvidedFile);
+            task.setInputFile(workspaceService.toWorkspaceRelativeString(inputPath));
+            Path outputPath = workspaceService.generateOutputPath(inputPath);
+            task.setOutputFile(workspaceService.toWorkspaceRelativeString(outputPath));
+            task.setStatus(VideoTaskStatus.PENDING);
+            task.setErrorMessage(null);
+        } catch (IllegalArgumentException ex) {
+            task.setStatus(VideoTaskStatus.ERROR);
+            task.setErrorMessage(ex.getMessage());
+        }
+        task.touch();
+        tasks.put(id, task);
+        return task;
+    }
+
+    public VideoTask executeTask(long taskId) {
+        VideoTask task = Optional.ofNullable(tasks.get(taskId))
+                .orElseThrow(() -> new NoSuchElementException("Task not found: " + taskId));
+
+        if (task.getStatus() == VideoTaskStatus.ERROR) {
+            return task;
+        }
+
+        try {
+            Path inputPath = workspaceService.resolveInputFile(task.getInputFile());
+            Path outputPath = workspaceService.generateOutputPath(inputPath);
+            task.setStatus(VideoTaskStatus.RUNNING);
+            task.touch();
+
+            if (outputPath.getParent() != null) {
+                Files.createDirectories(outputPath.getParent());
+            }
+            Files.copy(inputPath, outputPath, StandardCopyOption.REPLACE_EXISTING);
+
+            task.setOutputFile(workspaceService.toWorkspaceRelativeString(outputPath));
+            task.setStatus(VideoTaskStatus.COMPLETED);
+            task.setErrorMessage(null);
+        } catch (IllegalArgumentException | IOException ex) {
+            task.setStatus(VideoTaskStatus.ERROR);
+            task.setErrorMessage(ex.getMessage());
+        }
+
+        task.touch();
+        return task;
+    }
+
+    public Optional<VideoTask> getTask(long taskId) {
+        return Optional.ofNullable(tasks.get(taskId));
+    }
+
+    public List<VideoTask> getAllTasks() {
+        return tasks.values().stream()
+                .sorted(Comparator.comparingLong(VideoTask::getId))
+                .toList();
+    }
+}

--- a/src/main/java/com/example/authsystem/service/WorkspaceService.java
+++ b/src/main/java/com/example/authsystem/service/WorkspaceService.java
@@ -1,0 +1,171 @@
+package com.example.authsystem.service;
+
+import com.example.authsystem.config.VideoEditorProperties;
+import org.springframework.stereotype.Service;
+
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Service
+public class WorkspaceService {
+
+    private final VideoEditorProperties properties;
+    private final Set<String> allowedExtensions;
+
+    public WorkspaceService(VideoEditorProperties properties) {
+        this.properties = properties;
+        this.allowedExtensions = normalizeExtensions(properties.getAllowedExtensions());
+    }
+
+    public Path resolveInputFile(String userProvidedPath) {
+        if (userProvidedPath == null || userProvidedPath.isBlank()) {
+            throw new IllegalArgumentException("Input filename must not be blank");
+        }
+
+        Path workspaceRoot = getWorkspaceRoot();
+        Path resolvedPath = workspaceRoot.resolve(userProvidedPath).normalize();
+
+        if (!resolvedPath.startsWith(workspaceRoot)) {
+            throw new IllegalArgumentException("File must be located inside the configured workspace");
+        }
+
+        if (!Files.exists(resolvedPath) || !Files.isRegularFile(resolvedPath)) {
+            throw new IllegalArgumentException("File does not exist inside workspace: " + userProvidedPath);
+        }
+
+        String fileName = resolvedPath.getFileName().toString();
+        if (fileName.startsWith(getOutputPrefix())) {
+            throw new IllegalArgumentException("File already contains the output prefix: " + getOutputPrefix());
+        }
+
+        if (!isExtensionAllowed(fileName)) {
+            throw new IllegalArgumentException("File extension is not allowed: " + fileName);
+        }
+
+        return resolvedPath.toAbsolutePath();
+    }
+
+    public Path generateOutputPath(String userProvidedPath) {
+        Path inputPath = resolveInputFile(userProvidedPath);
+        return generateOutputPath(inputPath);
+    }
+
+    public Path generateOutputPath(Path inputFile) {
+        Path workspaceRoot = getWorkspaceRoot();
+        Path normalizedInput = inputFile.toAbsolutePath().normalize();
+        if (!normalizedInput.startsWith(workspaceRoot)) {
+            throw new IllegalArgumentException("Input file must be located inside the workspace");
+        }
+
+        String fileName = normalizedInput.getFileName().toString();
+        Path relative = workspaceRoot.relativize(normalizedInput);
+        Path parent = relative.getParent();
+        String outputFileName = getOutputPrefix() + fileName;
+
+        Path outputRelative = parent == null ? Paths.get(outputFileName) : parent.resolve(outputFileName);
+        Path outputPath = workspaceRoot.resolve(outputRelative).normalize();
+
+        if (!outputPath.startsWith(workspaceRoot)) {
+            throw new IllegalArgumentException("Output path must remain inside the workspace");
+        }
+
+        return outputPath;
+    }
+
+    public String generateOutputFilename(String userProvidedPath) {
+        Path outputPath = generateOutputPath(userProvidedPath);
+        return toWorkspaceRelativeString(outputPath);
+    }
+
+    public List<String> listWorkspaceContents() {
+        Path workspaceRoot = getWorkspaceRoot();
+        if (!Files.exists(workspaceRoot)) {
+            return Collections.emptyList();
+        }
+
+        try (Stream<Path> stream = Files.walk(workspaceRoot)) {
+            return stream.filter(Files::isRegularFile)
+                    .filter(this::isValidInputFile)
+                    .map(this::toWorkspaceRelativeString)
+                    .sorted()
+                    .collect(Collectors.toList());
+        } catch (java.io.IOException ex) {
+            throw new UncheckedIOException("Unable to read workspace contents", ex);
+        }
+    }
+
+    public String toWorkspaceRelativeString(Path absolutePath) {
+        Path workspaceRoot = getWorkspaceRoot();
+        Path relative = workspaceRoot.relativize(absolutePath.toAbsolutePath().normalize());
+        return relative.toString().replace('\', '/');
+    }
+
+    private boolean isValidInputFile(Path path) {
+        String fileName = path.getFileName().toString();
+        return !fileName.startsWith(getOutputPrefix()) && isExtensionAllowed(fileName);
+    }
+
+    private boolean isExtensionAllowed(String fileName) {
+        String extension = extractExtension(fileName);
+        if (extension.isEmpty()) {
+            return false;
+        }
+        return allowedExtensions.contains(extension);
+    }
+
+    private String extractExtension(String fileName) {
+        int index = fileName.lastIndexOf('.');
+        if (index < 0 || index == fileName.length() - 1) {
+            return "";
+        }
+        return fileName.substring(index + 1).toLowerCase();
+    }
+
+    private Path getWorkspaceRoot() {
+        Path configuredPath = properties.getWorkspacePath();
+        if (configuredPath == null) {
+            throw new IllegalStateException("Workspace path is not configured");
+        }
+        Path workspace = configuredPath.toAbsolutePath().normalize();
+        try {
+            Files.createDirectories(workspace);
+        } catch (java.io.IOException ex) {
+            throw new UncheckedIOException("Unable to create workspace directory", ex);
+        }
+        return workspace;
+    }
+
+    private String getOutputPrefix() {
+        String prefix = properties.getOutputPrefix();
+        return prefix == null ? "" : prefix;
+    }
+
+    private Set<String> normalizeExtensions(List<String> extensions) {
+        if (extensions == null) {
+            return Collections.emptySet();
+        }
+        Set<String> normalized = new HashSet<>();
+        for (String extension : extensions) {
+            if (extension == null) {
+                continue;
+            }
+            String trimmed = extension.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            if (trimmed.startsWith(".")) {
+                trimmed = trimmed.substring(1);
+            }
+            normalized.add(trimmed.toLowerCase());
+        }
+        return Collections.unmodifiableSet(normalized);
+    }
+}

--- a/src/main/java/com/example/authsystem/video/VideoTask.java
+++ b/src/main/java/com/example/authsystem/video/VideoTask.java
@@ -1,0 +1,74 @@
+package com.example.authsystem.video;
+
+import java.time.Instant;
+
+public class VideoTask {
+    private final long id;
+    private final String requestedFile;
+    private final Instant createdAt;
+    private Instant updatedAt;
+    private String inputFile;
+    private String outputFile;
+    private VideoTaskStatus status;
+    private String errorMessage;
+
+    public VideoTask(long id, String requestedFile) {
+        this.id = id;
+        this.requestedFile = requestedFile;
+        this.createdAt = Instant.now();
+        this.updatedAt = this.createdAt;
+        this.status = VideoTaskStatus.PENDING;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getRequestedFile() {
+        return requestedFile;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void touch() {
+        this.updatedAt = Instant.now();
+    }
+
+    public String getInputFile() {
+        return inputFile;
+    }
+
+    public void setInputFile(String inputFile) {
+        this.inputFile = inputFile;
+    }
+
+    public String getOutputFile() {
+        return outputFile;
+    }
+
+    public void setOutputFile(String outputFile) {
+        this.outputFile = outputFile;
+    }
+
+    public VideoTaskStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(VideoTaskStatus status) {
+        this.status = status;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+}

--- a/src/main/java/com/example/authsystem/video/VideoTaskStatus.java
+++ b/src/main/java/com/example/authsystem/video/VideoTaskStatus.java
@@ -1,0 +1,8 @@
+package com.example.authsystem.video;
+
+public enum VideoTaskStatus {
+    PENDING,
+    RUNNING,
+    COMPLETED,
+    ERROR
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,3 +45,11 @@ springdoc:
     path: /api-docs
   swagger-ui:
     path: /swagger-ui.html
+
+video-editor:
+  workspace-path: ./workspace
+  allowed-extensions:
+    - mp4
+    - mov
+    - mkv
+  output-prefix: edited_

--- a/src/test/java/com/example/authsystem/service/WorkspaceServiceTest.java
+++ b/src/test/java/com/example/authsystem/service/WorkspaceServiceTest.java
@@ -1,0 +1,58 @@
+package com.example.authsystem.service;
+
+import com.example.authsystem.config.VideoEditorProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WorkspaceServiceTest {
+
+    private WorkspaceService workspaceService;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setUp() {
+        VideoEditorProperties properties = new VideoEditorProperties();
+        properties.setWorkspacePath(tempDir);
+        properties.setAllowedExtensions(List.of("mp4", ".mov"));
+        properties.setOutputPrefix("edited_");
+        workspaceService = new WorkspaceService(properties);
+    }
+
+    @Test
+    void resolveInputFileReturnsAbsolutePathForValidInput() throws IOException {
+        Path videoFile = Files.createFile(tempDir.resolve("sample.mp4"));
+
+        Path resolved = workspaceService.resolveInputFile("sample.mp4");
+        assertEquals(videoFile.toAbsolutePath(), resolved);
+        assertTrue(resolved.isAbsolute());
+
+        Path generatedOutputPath = workspaceService.generateOutputPath(resolved);
+        assertEquals(tempDir.resolve("edited_sample.mp4"), generatedOutputPath);
+
+        String outputFilename = workspaceService.generateOutputFilename("sample.mp4");
+        assertEquals("edited_sample.mp4", outputFilename);
+    }
+
+    @Test
+    void resolveInputFileRejectsPathTraversal() {
+        assertThrows(IllegalArgumentException.class, () -> workspaceService.resolveInputFile("../secret.mp4"));
+    }
+
+    @Test
+    void resolveInputFileRejectsFilesWithOutputPrefix() throws IOException {
+        Files.createFile(tempDir.resolve("edited_existing.mp4"));
+        assertThrows(IllegalArgumentException.class, () -> workspaceService.resolveInputFile("edited_existing.mp4"));
+    }
+}


### PR DESCRIPTION
## Summary
- register VideoEditorProperties with defaults for video editing workspace
- add WorkspaceService with validation, integrate it into VideoTaskService and controller endpoints
- cover workspace resolution logic with unit tests including traversal and duplicate-prefix scenarios

## Testing
- mvn test *(fails: unable to resolve parent POM due to 403 response from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68f45f4540f8832aa6a02f6723b030b6